### PR TITLE
fix paths on linux & null exceptions

### DIFF
--- a/Rhythmic/Beatmap/BeatmapAPI.cs
+++ b/Rhythmic/Beatmap/BeatmapAPI.cs
@@ -25,11 +25,11 @@ namespace Rhythmic.Beatmap
             if (!ZipUtils.IsZipArchive(path))
                 return;
 
-            string directory = GetFolderPath(SpecialFolder.ApplicationData) + @"\Rhythmic\Database\Beatmaps\";
+            string directory = Path.Combine(GetFolderPath(SpecialFolder.ApplicationData), "Rhythmic", "Database", "Beatmaps");
             IArchive archive = ArchiveFactory.Open(path);
             foreach (IArchiveEntry entry in archive.Entries)
             {
-                if (!File.Exists(directory + entry.Key))
+                if (!File.Exists(Path.Combine(directory, entry.Key)))
                     entry.WriteToDirectory(directory, new ExtractionOptions
                     {
                         ExtractFullPath = true

--- a/Rhythmic/Beatmap/Properties/Level/Object/Object.cs
+++ b/Rhythmic/Beatmap/Properties/Level/Object/Object.cs
@@ -61,55 +61,55 @@ namespace Rhythmic.Beatmap.Properties.Level.Object
             {
                 float time = 0f;
 
-                if (ColourKeyframes.Any())
+                if (ColourKeyframes?.Any() == true)
                     foreach (Keyframe<float[]> t in ColourKeyframes)
                     {
                         time += (float)t.Time;
                     }
 
-                if (BorderColourKeyframes.Any())
+                if (BorderColourKeyframes?.Any() == true)
                     foreach (Keyframe<float[]> t in BorderColourKeyframes)
                     {
                         time += (float)t.Time;
                     }
 
-                if (FillKeyframes.Any())
+                if (FillKeyframes?.Any() == true)
                     foreach (Keyframe<double> t in FillKeyframes)
                     {
                         time += (float)t.Time;
                     }
 
-                if (InnerRadiusKeyframes.Any())
+                if (InnerRadiusKeyframes?.Any() == true)
                     foreach (Keyframe<float> t in InnerRadiusKeyframes)
                     {
                         time += (float)t.Time;
                     }
 
-                if (ShearKeyframes.Any())
+                if (ShearKeyframes?.Any() == true)
                     foreach (Keyframe<float[]> t in ShearKeyframes)
                     {
                         time += (float)t.Time;
                     }
 
-                if (MoveKeyframes.Any())
+                if (MoveKeyframes?.Any() == true)
                     foreach (Keyframe<double[]> t in MoveKeyframes)
                     {
                         time += (float)t.Time;
                     }
 
-                if (RotationKeyframes.Any())
+                if (RotationKeyframes?.Any() == true)
                     foreach (Keyframe<double> t in RotationKeyframes)
                     {
                         time += (float)t.Time;
                     }
 
-                if (ScaleKeyframes.Any())
+                if (ScaleKeyframes?.Any() == true)
                     foreach (Keyframe<double[]> t in ScaleKeyframes)
                     {
                         time += (float)t.Time;
                     }
 
-                if (BorderThicknessKeyframes.Any())
+                if (BorderThicknessKeyframes?.Any() == true)
                     foreach (Keyframe<double[]> t in BorderThicknessKeyframes)
                     {
                         time += (float)t.Time;

--- a/Rhythmic/RhythmicGameBase.cs
+++ b/Rhythmic/RhythmicGameBase.cs
@@ -92,7 +92,7 @@ namespace Rhythmic
 
         private void CreateRequiredFiles()
         {
-            string path = GetFolderPath(SpecialFolder.ApplicationData) + @"\Rhythmic\Database\";
+            string path = Path.Combine(GetFolderPath(SpecialFolder.ApplicationData), "Rhythmic", "Database");
 
             if (!Directory.Exists(path))
                 Directory.CreateDirectory(path);
@@ -101,8 +101,9 @@ namespace Rhythmic
 
             foreach (string folder in pathList)
             {
-                if (!Directory.Exists(path + folder))
-                    Directory.CreateDirectory(path + folder);
+                string folderPath = Path.Combine(path, folder);
+                if (!Directory.Exists(folderPath))
+                    Directory.CreateDirectory(folderPath);
             }
         }
     }

--- a/Rhythmic/Screens/Loader.cs
+++ b/Rhythmic/Screens/Loader.cs
@@ -78,12 +78,12 @@ namespace Rhythmic.Screens
 
         private void LoadAllBeatmaps()
         {
-            string path = GetFolderPath(SpecialFolder.ApplicationData) + @"\Rhythmic\Database\Beatmaps\";
+            string path = Path.Combine(GetFolderPath(SpecialFolder.ApplicationData), "Rhythmic", "Database", "Beatmaps");
 
             foreach (string file in Directory.EnumerateDirectories(path))
             {
                 API.GetBeatmapFromZip(file);
-                BeatmapMeta level = API.ParseBeatmap(File.ReadAllText(file + @"\level.json"));
+                BeatmapMeta level = API.ParseBeatmap(File.ReadAllText(Path.Combine(file, "level.json")));
 
                 BeatmapMeta beatmap = new BeatmapMeta
                 {
@@ -93,20 +93,22 @@ namespace Rhythmic.Screens
                     SongUrl = level.SongUrl
                 };
 
-                if (!beatmap.SongUrl.StartsWith(@"\"))
-                    beatmap.SongUrl = Concat(@"\", beatmap.SongUrl);
+                if (beatmap.SongUrl?.StartsWith(Path.DirectorySeparatorChar) == false)
+                    beatmap.SongUrl = Path.DirectorySeparatorChar + beatmap.SongUrl;
 
-                if (!beatmap.Metadata.LogoURL.StartsWith(@"\"))
-                    beatmap.Metadata.LogoURL = Concat(@"\", beatmap.Metadata.LogoURL);
+                if (beatmap.Metadata?.LogoURL?.StartsWith(Path.DirectorySeparatorChar) == false)
+                    beatmap.Metadata.LogoURL = Path.DirectorySeparatorChar + beatmap.Metadata.LogoURL;
 
-                if (!beatmap.Metadata.BackgroundURL.StartsWith(@"\"))
-                    beatmap.Metadata.BackgroundURL = Concat(@"\", beatmap.Metadata.BackgroundURL);
+                if (!beatmap.Metadata?.BackgroundURL?.StartsWith(Path.DirectorySeparatorChar) == false)
+                    beatmap.Metadata.BackgroundURL = Path.DirectorySeparatorChar + beatmap.Metadata.BackgroundURL;
 
                 FileStream SongStream = File.OpenRead(file + beatmap.SongUrl);
 
                 beatmap.Song = new TrackBass(SongStream);
-                beatmap.Logo = Texture.FromStream(File.OpenRead(file + beatmap.Metadata.LogoURL));
-                beatmap.Background = Texture.FromStream(File.OpenRead(file + beatmap.Metadata.BackgroundURL));
+                if (beatmap.Metadata?.LogoURL != null)
+                    beatmap.Logo = Texture.FromStream(File.OpenRead(file + beatmap.Metadata.LogoURL));
+                if (beatmap.Metadata?.BackgroundURL != null)
+                    beatmap.Background = Texture.FromStream(File.OpenRead(file + beatmap.Metadata.BackgroundURL));
 
                 collection.Beatmaps.Add(beatmap);
             }


### PR DESCRIPTION
Game source used `\` as directory separator (now using Path.Combine) and the example beatmap (?) in `Rhythmic.Resources/Beatmap` couldn't be loaded ingame because of null crashes.